### PR TITLE
Add `CHANGELOG.md` to `extra-source-files`

### DIFF
--- a/resource-pool.cabal
+++ b/resource-pool.cabal
@@ -19,6 +19,9 @@ tested-with: GHC ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.3
 extra-doc-files:
   CHANGELOG.md
   README.md
+  
+extra-source-files:
+  CHANGELOG.md
 
 bug-reports: https://github.com/scrive/pool/issues
 source-repository head


### PR DESCRIPTION
The Changelog link doesn't show up in Hackage without the `extra-source-files` stanza.