### PR TITLE
Allow user to configure stripe count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dist-newstyle/

--- a/src/Data/Pool.hs
+++ b/src/Data/Pool.hs
@@ -102,7 +102,8 @@ createPool create free numStripes idleTime maxResources = newPool PoolConfig
   { createResource   = create
   , freeResource     = free
   , poolCacheTTL     = realToFrac idleTime
-  , poolMaxResources = numStripes * maxResources
+  , poolMaxResources = maxResources
+  , poolNumStripes   = Just numStripes
   }
 
 ----------------------------------------


### PR DESCRIPTION
There's a behavior difference in how the number of stripes vs the number of resources play together. While greater stripe count may benefit performance, it also allows more resources to be created.

This patch changes the code such that the number of stripes is specified and preserved.