### PR TITLE
Don't exceed maximum resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dist-newstyle/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# resource-pool-0.4.0.0 (???)
+* Allow user to configure the number of stripes explicitly. [#15](https://github.com/scrive/pool/pull/15)
+
 # resource-pool-0.3.1.0 (2022-06-15)
 * Add `tryWithResource` and `tryTakeResource`.
 

--- a/src/Data/Pool.hs
+++ b/src/Data/Pool.hs
@@ -102,7 +102,8 @@ createPool create free numStripes idleTime maxResources = newPool PoolConfig
   { createResource   = create
   , freeResource     = free
   , poolCacheTTL     = realToFrac idleTime
-  , poolMaxResources = numStripes * maxResources
+  , poolMaxResources = maxResources
+  , poolNumStripes   = Just numStripes
   }
 
 ----------------------------------------


### PR DESCRIPTION
This PR builds on #15 

Fixes #13 

This PR has two main behavior changes:

1. If `numStripes` is greater than `maxResources`, then we only create `maxResources` of stripes, each receiving a single resource.
2. If `numStripes` does not evenly divide `maxResources`, then the final stripe contains the *remainder* of that division, instead of the full amount.

With these two changes, `poolMaxResources` is guaranteed to be a true maximum of resources.