### PR TITLE
Use capability-local stripes regardless of configuration

### DIFF
--- a/src/Data/Pool.hs
+++ b/src/Data/Pool.hs
@@ -58,7 +58,7 @@ withResource pool act = mask $ \unmask -> do
 -- to the pool (via 'putResource').
 takeResource :: Pool a -> IO (a, LocalPool a)
 takeResource pool = mask_ $ do
-  lp <- getLocalPool (poolNumStripes $ poolConfig pool) (localPools pool)
+  lp <- getLocalPool (localPools pool)
   stripe <- takeMVar (stripeVar lp)
   if available stripe == 0
     then do
@@ -85,7 +85,7 @@ tryWithResource pool act = mask $ \unmask -> tryTakeResource pool >>= \case
 -- the local pool is exhausted.
 tryTakeResource :: Pool a -> IO (Maybe (a, LocalPool a))
 tryTakeResource pool = mask_ $ do
-  lp <- getLocalPool (poolNumStripes $ poolConfig pool) (localPools pool)
+  lp <- getLocalPool (localPools pool)
   stripe <- takeMVar (stripeVar lp)
   if available stripe == 0
     then do

--- a/src/Data/Pool/Internal.hs
+++ b/src/Data/Pool/Internal.hs
@@ -181,7 +181,7 @@ getLocalPool pools = do
         -- If there's only one stripe, then we want to skip any work - the
         -- index is always going to be 0.
         pure 0
-      _ | stripeCount <= capabilities ->
+      _ | stripeCount <= capabilities && rem capabilities stripeCount /= 0 ->
         -- If the number of stripes is at most the number of capabilities,
         -- then we can ensure that a capability is always using a single
         -- stripe.

--- a/src/Data/Pool/Introspection.hs
+++ b/src/Data/Pool/Introspection.hs
@@ -55,7 +55,7 @@ withResource pool act = mask $ \unmask -> do
 takeResource :: Pool a -> IO (Resource a, LocalPool a)
 takeResource pool = mask_ $ do
   t1 <- getMonotonicTime
-  lp <- getLocalPool (poolNumStripes $ poolConfig pool) (localPools pool)
+  lp <- getLocalPool (localPools pool)
   stripe <- takeMVar (stripeVar lp)
   if available stripe == 0
     then do
@@ -103,7 +103,7 @@ tryWithResource pool act = mask $ \unmask -> tryTakeResource pool >>= \case
 tryTakeResource :: Pool a -> IO (Maybe (Resource a, LocalPool a))
 tryTakeResource pool = mask_ $ do
   t1 <- getMonotonicTime
-  lp <- getLocalPool (poolNumStripes $ poolConfig pool) (localPools pool)
+  lp <- getLocalPool (localPools pool)
   stripe <- takeMVar (stripeVar lp)
   if available stripe == 0
     then do


### PR DESCRIPTION
This PR uses the number of capabilities to determine how to select stripes, instead of the pool configuration.

This should reduce the amount of contention for the case where the number of stripes is less than the number of capabilities.