### PR TITLE
Hide the constructor of PoolConfig from the public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # resource-pool-0.4.0.0 (????-??-??)
 * Require `poolMaxResources` to be not smaller than the number of stripes.
 * Add support for setting the number of stripes.
+* Hide the constructor of `PoolConfig` from the public API and provide
+  `defaultPoolConfig` so that future additions to `PoolConfig` don't require
+  major version bumps.
 
 # resource-pool-0.3.1.0 (2022-06-15)
 * Add `tryWithResource` and `tryTakeResource`.

--- a/src/Data/Pool.hs
+++ b/src/Data/Pool.hs
@@ -2,10 +2,14 @@
 -- collections of resources such as database connections.
 module Data.Pool
   ( -- * Pool
-    PoolConfig(..)
-  , Pool
+    Pool
   , LocalPool
   , newPool
+
+    -- ** Configuration
+  , PoolConfig
+  , defaultPoolConfig
+  , setNumStripes
 
     -- * Resource management
   , withResource

--- a/src/Data/Pool/Introspection.hs
+++ b/src/Data/Pool/Introspection.hs
@@ -1,10 +1,14 @@
 -- | A variant of "Data.Pool" with introspection capabilities.
 module Data.Pool.Introspection
   ( -- * Pool
-    PoolConfig(..)
-  , Pool
+    Pool
   , LocalPool
   , newPool
+
+  -- ** Configuration
+  , PoolConfig
+  , defaultPoolConfig
+  , setNumStripes
 
     -- * Resource management
   , Resource(..)


### PR DESCRIPTION
Fixes #14.