### PR TITLE
Extension of `withResource` which creates a fresh resource if it fails instead of just throwing

### DIFF
--- a/resource-pool.cabal
+++ b/resource-pool.cabal
@@ -36,6 +36,7 @@ library
   build-depends: base >= 4.11 && < 5
                , hashable >= 1.1.0.0
                , primitive >= 0.7
+               , safe-exceptions
                , time
 
   ghc-options: -Wall -Wcompat


### PR DESCRIPTION
Apologies if this doesn't fit the code/documentation style, feel free to edit.

Just a quick PR with some utility code I've written based on your library. Figure it would be good to get into the library proper, and thought it would be good for you to see it to check I'm not doing something very dumb. 

Rational and description I've tried to make clear through the comments, but do shout out if you're unsure of anything.

If you think this doesn't fit in this library, just say, I'm happy to go put this in a separate library that just depends of `pool` if you think that's more appropriate.