### PR TITLE
Lockless implementation

### DIFF
--- a/resource-pool.cabal
+++ b/resource-pool.cabal
@@ -35,6 +35,7 @@ library
   build-depends: base >= 4.11 && < 5
                , hashable >= 1.1.0.0
                , primitive >= 0.7
+               , stm
                , time
 
   ghc-options: -Wall -Wcompat
@@ -44,4 +45,5 @@ library
   default-extensions: DeriveGeneric
                     , LambdaCase
                     , RankNTypes
+                    , ScopedTypeVariables
                     , TypeApplications

--- a/src/Data/Pool/Introspection.hs
+++ b/src/Data/Pool/Introspection.hs
@@ -22,9 +22,10 @@ module Data.Pool.Introspection
   , destroyAllResources
   ) where
 
-import Control.Concurrent
+import Control.Concurrent.STM
 import Control.Exception
-import GHC.Clock
+import Control.Monad
+import GHC.Clock (getMonotonicTime)
 import GHC.Generics (Generic)
 
 import Data.Pool.Internal
@@ -61,39 +62,41 @@ takeResource :: Pool a -> IO (Resource a, LocalPool a)
 takeResource pool = mask_ $ do
   t1 <- getMonotonicTime
   lp <- getLocalPool (localPools pool)
-  stripe <- takeMVar (stripeVar lp)
-  if available stripe == 0
-    then do
-      q <- newEmptyMVar
-      putMVar (stripeVar lp) $! stripe {queueR = Queue q (queueR stripe)}
-      waitForResource (stripeVar lp) q >>= \case
-        Just a -> do
-          t2 <- getMonotonicTime
-          let res =
-                Resource
-                  { resource = a
-                  , stripeNumber = stripeId lp
-                  , availableResources = 0
-                  , acquisition = Delayed
-                  , acquisitionTime = t2 - t1
-                  , creationTime = Nothing
-                  }
-          pure (res, lp)
-        Nothing -> do
-          t2 <- getMonotonicTime
-          a <- createResource (poolConfig pool) `onException` restoreSize (stripeVar lp)
-          t3 <- getMonotonicTime
-          let res =
-                Resource
-                  { resource = a
-                  , stripeNumber = stripeId lp
-                  , availableResources = 0
-                  , acquisition = Delayed
-                  , acquisitionTime = t2 - t1
-                  , creationTime = Just $! t3 - t2
-                  }
-          pure (res, lp)
-    else takeAvailableResource pool t1 lp stripe
+  join . atomically $ do
+    stripe <- readTVar (stripeVar lp)
+    if available stripe == 0
+      then do
+        q <- newEmptyTMVar
+        writeTVar (stripeVar lp) $! stripe {queueR = Queue q (queueR stripe)}
+        pure $
+          waitForResource (stripeVar lp) q >>= \case
+            Just a -> do
+              t2 <- getMonotonicTime
+              let res =
+                    Resource
+                      { resource = a
+                      , stripeNumber = stripeId lp
+                      , availableResources = 0
+                      , acquisition = Delayed
+                      , acquisitionTime = t2 - t1
+                      , creationTime = Nothing
+                      }
+              pure (res, lp)
+            Nothing -> do
+              t2 <- getMonotonicTime
+              a <- createResource (poolConfig pool) `onException` restoreSize (stripeVar lp)
+              t3 <- getMonotonicTime
+              let res =
+                    Resource
+                      { resource = a
+                      , stripeNumber = stripeId lp
+                      , availableResources = 0
+                      , acquisition = Delayed
+                      , acquisitionTime = t2 - t1
+                      , creationTime = Just $! t3 - t2
+                      }
+              pure (res, lp)
+      else takeAvailableResource pool t1 lp stripe
 
 -- | A variant of 'withResource' that doesn't execute the action and returns
 -- 'Nothing' instead of blocking if the local pool is exhausted.
@@ -112,12 +115,13 @@ tryTakeResource :: Pool a -> IO (Maybe (Resource a, LocalPool a))
 tryTakeResource pool = mask_ $ do
   t1 <- getMonotonicTime
   lp <- getLocalPool (localPools pool)
-  stripe <- takeMVar (stripeVar lp)
-  if available stripe == 0
-    then do
-      putMVar (stripeVar lp) stripe
-      pure Nothing
-    else Just <$> takeAvailableResource pool t1 lp stripe
+  join . atomically $ do
+    stripe <- readTVar (stripeVar lp)
+    if available stripe == 0
+      then do
+        writeTVar (stripeVar lp) stripe
+        pure $ pure Nothing
+      else fmap Just <$> takeAvailableResource pool t1 lp stripe
 
 ----------------------------------------
 -- Helpers
@@ -127,35 +131,37 @@ takeAvailableResource
   -> Double
   -> LocalPool a
   -> Stripe a
-  -> IO (Resource a, LocalPool a)
+  -> STM (IO (Resource a, LocalPool a))
 takeAvailableResource pool t1 lp stripe = case cache stripe of
   [] -> do
     let newAvailable = available stripe - 1
-    putMVar (stripeVar lp) $! stripe {available = newAvailable}
-    t2 <- getMonotonicTime
-    a <- createResource (poolConfig pool) `onException` restoreSize (stripeVar lp)
-    t3 <- getMonotonicTime
-    let res =
-          Resource
-            { resource = a
-            , stripeNumber = stripeId lp
-            , availableResources = newAvailable
-            , acquisition = Immediate
-            , acquisitionTime = t2 - t1
-            , creationTime = Just $! t3 - t2
-            }
-    pure (res, lp)
+    writeTVar (stripeVar lp) $! stripe {available = newAvailable}
+    pure $ do
+      t2 <- getMonotonicTime
+      a <- createResource (poolConfig pool) `onException` restoreSize (stripeVar lp)
+      t3 <- getMonotonicTime
+      let res =
+            Resource
+              { resource = a
+              , stripeNumber = stripeId lp
+              , availableResources = newAvailable
+              , acquisition = Immediate
+              , acquisitionTime = t2 - t1
+              , creationTime = Just $! t3 - t2
+              }
+      pure (res, lp)
   Entry a _ : as -> do
     let newAvailable = available stripe - 1
-    putMVar (stripeVar lp) $! stripe {available = newAvailable, cache = as}
-    t2 <- getMonotonicTime
-    let res =
-          Resource
-            { resource = a
-            , stripeNumber = stripeId lp
-            , availableResources = newAvailable
-            , acquisition = Immediate
-            , acquisitionTime = t2 - t1
-            , creationTime = Nothing
-            }
-    pure (res, lp)
+    writeTVar (stripeVar lp) $! stripe {available = newAvailable, cache = as}
+    pure $ do
+      t2 <- getMonotonicTime
+      let res =
+            Resource
+              { resource = a
+              , stripeNumber = stripeId lp
+              , availableResources = newAvailable
+              , acquisition = Immediate
+              , acquisitionTime = t2 - t1
+              , creationTime = Nothing
+              }
+      pure (res, lp)


### PR DESCRIPTION
MVar-based pool seems to exhibit horrible lock contention in specific workloads (especially with a single stripe), let's try a lockless implementation with STM.

Putting resources back doesn't block now so note "signal uninterruptible" no longer applies.